### PR TITLE
feat: add grafana and prometheus to stack

### DIFF
--- a/oracle/clickhouse/settings.xml
+++ b/oracle/clickhouse/settings.xml
@@ -1,5 +1,13 @@
 <clickhouse>
-    <format_schema>
-        <allow_absolute_path>1</allow_absolute_path>
-    </format_schema>
+    <listen_host>0.0.0.0</listen_host>
+    <http_port>8123</http_port>
+    <tcp_port>9000</tcp_port>
+    <prometheus>
+        <endpoint>/metrics</endpoint>
+        <port>9363</port>
+        <metrics>true</metrics>
+        <events>true</events>
+        <asynchronous_metrics>true</asynchronous_metrics>
+        <errors>true</errors>
+    </prometheus>
 </clickhouse>

--- a/oracle/clickhouse/tables.sql
+++ b/oracle/clickhouse/tables.sql
@@ -66,6 +66,7 @@ CREATE TABLE IF NOT EXISTS raw_qos_data
     )
 ) ENGINE = MergeTree()
 ORDER BY (event_time, gateway_id)
+PARTITION BY toYYYYMMDD(event_time)
 TTL event_time + INTERVAL 7 DAY;
 
 -- Create a simplified materialized view
@@ -101,7 +102,8 @@ CREATE TABLE IF NOT EXISTS qos_data
         blocks_behind UInt64
     )
 ) ENGINE = MergeTree()
-ORDER BY (event_time, gateway_id, query_id);
+ORDER BY (event_time, gateway_id, query_id)
+PARTITION BY toYYYYMMDD(event_time);
 
 -- Only create the materialized view if it doesn't exist already
 CREATE MATERIALIZED VIEW IF NOT EXISTS qos_data_mv TO qos_data AS

--- a/oracle/docker-compose.yml
+++ b/oracle/docker-compose.yml
@@ -152,7 +152,7 @@ services:
       - '--storage.tsdb.path=/prometheus'
       - '--storage.tsdb.retention.time=7d'   # Example retention: 7 days
       - '--web.enable-lifecycle'            # If you want to allow config reload via HTTP
-    export:
+    expose:
       - "9090"
     ports:
       - '9090:9090'

--- a/oracle/docker-compose.yml
+++ b/oracle/docker-compose.yml
@@ -168,9 +168,10 @@ services:
     depends_on:
       - prometheus
     environment:
-      GF_SECURITY_ADMIN_USER: admin
-      GF_SECURITY_ADMIN_PASSWORD: secret
       GF_PATHS_PROVISIONING: /etc/grafana/provisioning
+      GF_AUTH_ANONYMOUS_ENABLED: true
+      GF_AUTH_ANONYMOUS_ORG_ROLE: Admin
+      GF_AUTH_BASIC_ENABLED: false
     expose:
       - "3000"
     ports:
@@ -191,4 +192,8 @@ volumes:
   redpanda_data:
     driver: local
   prometheus_data:
+    driver: local
+  grafana_data:
+    driver: local
+  grafana_provisioning:
     driver: local

--- a/oracle/docker-compose.yml
+++ b/oracle/docker-compose.yml
@@ -19,13 +19,16 @@ services:
     expose:
       - "8123"  # HTTP interface
       - "9000"  # Native protocol
+      - "9363"  # Prometheus
     ports:
       - "8123:8123"  # HTTP: queries/monitoring
       - "9000:9000"  # Native: client connections
+      - "9363:9363"  # Prometheus
     volumes:
       - ./clickhouse/schema.proto:/etc/clickhouse-server/schema.proto:ro
       - ./clickhouse/tables.sql:/docker-entrypoint-initdb.d/tables.sql:ro
       - ./clickhouse/allow_schema_path.xml:/etc/clickhouse-server/config.d/allow_schema_path.xml:ro
+      - ./clickhouse/settings.xml:/etc/clickhouse-server/config.d/settings.xml:ro
       - clickhouse_data:/var/lib/clickhouse
       - clickhouse_logs:/var/log/clickhouse-server
     ulimits:
@@ -42,10 +45,12 @@ services:
     image: redpandadata/redpanda:latest
     profiles: [all, deps, dev]
     expose:
-      - "9092"  # Kafka API
-      - "8082"  # Pandaproxy HTTP
+      - "9092"   # Kafka API
+      - "8082"   # Pandaproxy HTTP
+      - "9644"   # Prometheus metrics
     ports:
-      - "9092:9092"  # Kafka: producer/consumer
+      - "9092:9092" # Kafka: producer/consumer
+      - "9644:9644"
     command:
       - redpanda
       - start
@@ -112,6 +117,7 @@ services:
       test: ["CMD-SHELL", "ps aux | grep -v grep | grep -q qos_kafka_producer || exit 1"]
 
   redpanda-console:
+    profiles: [all, dev]
     image: redpandadata/console:latest
     container_name: redpanda-console
     depends_on:
@@ -130,10 +136,59 @@ services:
       retries: 5
       start_period: 10s
 
+  # Observability: Prometheus + Grafana
+  prometheus:
+    profiles: [all, dev, deps]
+    image: prom/prometheus:latest
+    container_name: prometheus
+    depends_on:
+      - redpanda
+    volumes:
+      - ./prometheus:/etc/prometheus:ro
+      # This volume will store TSDB data so metrics persist across restarts
+      - prometheus_data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--storage.tsdb.retention.time=7d'   # Example retention: 7 days
+      - '--web.enable-lifecycle'            # If you want to allow config reload via HTTP
+    export:
+      - "9090"
+    ports:
+      - '9090:9090'
+    healthcheck:
+      <<: *default-healthcheck
+      test: ["CMD-SHELL", "wget --spider -q http://localhost:9090/-/healthy || exit 1"]
+      start_period: 10s
+
+  grafana:
+    profiles: [all, dev, deps]
+    image: grafana/grafana:latest
+    container_name: grafana
+    depends_on:
+      - prometheus
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: secret
+      GF_PATHS_PROVISIONING: /etc/grafana/provisioning
+    expose:
+      - "3000"
+    ports:
+      - "3000:3000"
+    healthcheck:
+      <<: *default-healthcheck
+      test: ["CMD-SHELL", "curl -f http://localhost:3000/api/health || exit 1"]
+      start_period: 10s
+    volumes:
+      - ./grafana/provisioning/:/etc/grafana/provisioning/
+      - ./grafana/dashboards/:/var/lib/grafana/dashboards/
+
 # Persistent volumes
 volumes:
-  clickhouse_data:  # clickhouse persistent storage
+  clickhouse_data:
     driver: local
   clickhouse_logs:
-  redpanda_data:  # redpanda persistent storage 
+  redpanda_data:
+    driver: local
+  prometheus_data:
     driver: local

--- a/oracle/grafana/dashboards/qos_oracle_dashboard.json
+++ b/oracle/grafana/dashboards/qos_oracle_dashboard.json
@@ -117,12 +117,12 @@
       "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
       "targets": [
         {
-          "expr": "rate(vectorized_cluster_partition_records_produced[1m])",
+          "expr": "rate(vectorized_cluster_partition_records_produced[5m])",
           "legendFormat": "Produced",
           "refId": "A"
         },
         {
-          "expr": "rate(vectorized_cluster_partition_records_fetched[1m])",
+          "expr": "rate(vectorized_cluster_partition_records_fetched[5m])",
           "legendFormat": "Fetched",
           "refId": "B"
         }
@@ -136,12 +136,12 @@
       "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
       "targets": [
         {
-          "expr": "rate(vectorized_cluster_partition_bytes_produced_total[1m])",
+          "expr": "rate(vectorized_cluster_partition_bytes_produced_total[5m])",
           "legendFormat": "Bytes Produced",
           "refId": "A"
         },
         {
-          "expr": "rate(vectorized_cluster_partition_bytes_fetched_total[1m])",
+          "expr": "rate(vectorized_cluster_partition_bytes_fetched_total[5m])",
           "legendFormat": "Bytes Fetched",
           "refId": "B"
         }
@@ -162,7 +162,7 @@
       "gridPos": { "h": 8, "w": 8, "x": 0, "y": 15 },
       "targets": [
         {
-          "expr": "rate(vectorized_kafka_handler_latency_microseconds[1m])",
+          "expr": "rate(vectorized_kafka_handler_latency_microseconds_count[5m])",
           "legendFormat": "Handler Latency",
           "refId": "A"
         }
@@ -211,7 +211,7 @@
       "gridPos": { "h": 8, "w": 12, "x": 0, "y": 24 },
       "targets": [
         {
-          "expr": "irate(vectorized_reactor_cpu_busy_ms[1m])",
+          "expr": "irate(vectorized_reactor_cpu_busy_ms[5m])",
           "legendFormat": "{{instance}}",
           "refId": "A"
         }
@@ -264,12 +264,12 @@
       "gridPos": { "h": 8, "w": 12, "x": 12, "y": 32 },
       "targets": [
         {
-          "expr": "irate(vectorized_io_queue_delay[1m])",
+          "expr": "irate(vectorized_io_queue_delay[5m])",
           "legendFormat": "I/O Delay (ms)",
           "refId": "A"
         },
         {
-          "expr": "irate(vectorized_io_queue_consumption[1m])",
+          "expr": "irate(vectorized_io_queue_consumption[5m])",
           "legendFormat": "I/O Consumption (ms)",
           "refId": "B"
         }
@@ -332,7 +332,7 @@
       "gridPos": { "h": 8, "w": 12, "x": 0, "y": 45 },
       "targets": [
         {
-          "expr": "rate(ClickHouseProfileEvents_Query[1m])",
+          "expr": "rate(ClickHouseProfileEvents_Query[5m])",
           "legendFormat": "Queries/s",
           "refId": "A"
         }
@@ -346,7 +346,7 @@
       "gridPos": { "h": 8, "w": 12, "x": 12, "y": 45 },
       "targets": [
         {
-          "expr": "rate(ClickHouseProfileEvents_QueryTimeMicroseconds[1m])",
+          "expr": "rate(ClickHouseProfileEvents_QueryTimeMicroseconds[5m])",
           "legendFormat": "Query Time µs/s",
           "refId": "A"
         }
@@ -367,7 +367,7 @@
       "gridPos": { "h": 8, "w": 8, "x": 0, "y": 54 },
       "targets": [
         {
-          "expr": "rate(ClickHouseProfileEvents_InsertedRows[1m])",
+          "expr": "rate(ClickHouseProfileEvents_InsertedRows[5m])",
           "legendFormat": "Rows/s",
           "refId": "A"
         }
@@ -381,7 +381,7 @@
       "gridPos": { "h": 8, "w": 8, "x": 8, "y": 54 },
       "targets": [
         {
-          "expr": "rate(ClickHouseProfileEvents_MergedRows[1m])",
+          "expr": "rate(ClickHouseProfileEvents_MergedRows[5m])",
           "legendFormat": "Merged/s",
           "refId": "A"
         }
@@ -395,7 +395,7 @@
       "gridPos": { "h": 8, "w": 8, "x": 16, "y": 54 },
       "targets": [
         {
-          "expr": "rate(ClickHouseProfileEvents_MergesTimeMilliseconds[1m])",
+          "expr": "rate(ClickHouseProfileEvents_MergesTimeMilliseconds[5m])",
           "legendFormat": "Merges Time ms/s",
           "refId": "A"
         }

--- a/oracle/grafana/dashboards/qos_oracle_dashboard.json
+++ b/oracle/grafana/dashboards/qos_oracle_dashboard.json
@@ -1,0 +1,452 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "panels": [
+    {
+      "type": "row",
+      "title": "Redpanda Overview",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "stat",
+      "title": "Redpanda Uptime (seconds)",
+      "id": 1,
+      "datasource": "Prometheus",
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 1 },
+      "targets": [
+        {
+          "expr": "vectorized_application_uptime",
+          "legendFormat": "Instance: {{instance}}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto"
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Redpanda Build Info",
+      "id": 2,
+      "datasource": "Prometheus",
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 1 },
+      "targets": [
+        {
+          "expr": "vectorized_application_build",
+          "legendFormat": "Build: {{version}}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto"
+      }
+    },
+    {
+      "type": "stat",
+      "title": "FIPS Mode",
+      "id": 3,
+      "datasource": "Prometheus",
+      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 1 },
+      "targets": [
+        {
+          "expr": "vectorized_application_fips_mode",
+          "legendFormat": "{{instance}} - FIPS",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto"
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Under-Replicated Partitions",
+      "id": 4,
+      "datasource": "Prometheus",
+      "gridPos": { "h": 4, "w": 4, "x": 12, "y": 1 },
+      "targets": [
+        {
+          "expr": "vectorized_cluster_partition_under_replicated_replicas",
+          "legendFormat": "URP",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto"
+      }
+    },
+    {
+      "type": "row",
+      "title": "Redpanda Traffic & Throughput",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Records Produced / Fetched per Sec",
+      "id": 5,
+      "datasource": "Prometheus",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "targets": [
+        {
+          "expr": "rate(vectorized_cluster_partition_records_produced[1m])",
+          "legendFormat": "Produced",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(vectorized_cluster_partition_records_fetched[1m])",
+          "legendFormat": "Fetched",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Bytes Produced / Fetched per Sec",
+      "id": 6,
+      "datasource": "Prometheus",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "targets": [
+        {
+          "expr": "rate(vectorized_cluster_partition_bytes_produced_total[1m])",
+          "legendFormat": "Bytes Produced",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(vectorized_cluster_partition_bytes_fetched_total[1m])",
+          "legendFormat": "Bytes Fetched",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Redpanda Latencies & Connection Health",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 14 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Kafka Handler Latency (µs)",
+      "id": 7,
+      "datasource": "Prometheus",
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 15 },
+      "targets": [
+        {
+          "expr": "rate(vectorized_kafka_handler_latency_microseconds[1m])",
+          "legendFormat": "Handler Latency",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Active Kafka Connections",
+      "id": 8,
+      "datasource": "Prometheus",
+      "gridPos": { "h": 4, "w": 8, "x": 8, "y": 15 },
+      "targets": [
+        {
+          "expr": "vectorized_kafka_rpc_active_connections",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Rejected Kafka Connections",
+      "id": 9,
+      "datasource": "Prometheus",
+      "gridPos": { "h": 4, "w": 8, "x": 16, "y": 15 },
+      "targets": [
+        {
+          "expr": "vectorized_kafka_rpc_connections_rejected",
+          "legendFormat": "Rejected",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Redpanda Resource Usage",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 23 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "CPU Busy ms/s (approx)",
+      "id": 10,
+      "datasource": "Prometheus",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 24 },
+      "targets": [
+        {
+          "expr": "irate(vectorized_reactor_cpu_busy_ms[1m])",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "description": "CPU busy time in ms; using irate for approximate CPU usage."
+    },
+    {
+      "type": "timeseries",
+      "title": "Memory Used / Available",
+      "id": 11,
+      "datasource": "Prometheus",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
+      "targets": [
+        {
+          "expr": "vectorized_memory_allocated_memory",
+          "legendFormat": "Allocated",
+          "refId": "A"
+        },
+        {
+          "expr": "vectorized_memory_available_memory",
+          "legendFormat": "Available",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Disk Usage",
+      "id": 12,
+      "datasource": "Prometheus",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 32 },
+      "targets": [
+        {
+          "expr": "vectorized_space_management_disk_usage_bytes",
+          "legendFormat": "Used Bytes",
+          "refId": "A"
+        },
+        {
+          "expr": "vectorized_space_management_target_disk_size_bytes",
+          "legendFormat": "Target Disk Size",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "I/O Queue Delays & Consumption",
+      "id": 13,
+      "datasource": "Prometheus",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 32 },
+      "targets": [
+        {
+          "expr": "irate(vectorized_io_queue_delay[1m])",
+          "legendFormat": "I/O Delay (ms)",
+          "refId": "A"
+        },
+        {
+          "expr": "irate(vectorized_io_queue_consumption[1m])",
+          "legendFormat": "I/O Consumption (ms)",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "ClickHouse Overview",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 40 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "stat",
+      "title": "Total Queries",
+      "id": 14,
+      "datasource": "Prometheus",
+      "gridPos": { "h": 4, "w": 8, "x": 0, "y": 41 },
+      "targets": [
+        {
+          "expr": "ClickHouseProfileEvents_Query",
+          "legendFormat": "All Queries",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Select Queries (Total)",
+      "id": 15,
+      "datasource": "Prometheus",
+      "gridPos": { "h": 4, "w": 8, "x": 8, "y": 41 },
+      "targets": [
+        {
+          "expr": "ClickHouseProfileEvents_SelectQuery",
+          "legendFormat": "Select",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Insert Queries (Total)",
+      "id": 16,
+      "datasource": "Prometheus",
+      "gridPos": { "h": 4, "w": 8, "x": 16, "y": 41 },
+      "targets": [
+        {
+          "expr": "ClickHouseProfileEvents_InsertQuery",
+          "legendFormat": "Insert",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Queries per Second",
+      "id": 17,
+      "datasource": "Prometheus",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 45 },
+      "targets": [
+        {
+          "expr": "rate(ClickHouseProfileEvents_Query[1m])",
+          "legendFormat": "Queries/s",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Query Time (µs) Rate",
+      "id": 18,
+      "datasource": "Prometheus",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 45 },
+      "targets": [
+        {
+          "expr": "rate(ClickHouseProfileEvents_QueryTimeMicroseconds[1m])",
+          "legendFormat": "Query Time µs/s",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "ClickHouse Inserts & Merges",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 53 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Inserted Rows/s",
+      "id": 19,
+      "datasource": "Prometheus",
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 54 },
+      "targets": [
+        {
+          "expr": "rate(ClickHouseProfileEvents_InsertedRows[1m])",
+          "legendFormat": "Rows/s",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Merged Rows/s",
+      "id": 20,
+      "datasource": "Prometheus",
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 54 },
+      "targets": [
+        {
+          "expr": "rate(ClickHouseProfileEvents_MergedRows[1m])",
+          "legendFormat": "Merged/s",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Merges Time (ms/s)",
+      "id": 21,
+      "datasource": "Prometheus",
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 54 },
+      "targets": [
+        {
+          "expr": "rate(ClickHouseProfileEvents_MergesTimeMilliseconds[1m])",
+          "legendFormat": "Merges Time ms/s",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "ClickHouse Resource Usage",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 62 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "ClickHouse Memory Tracking (bytes)",
+      "id": 22,
+      "datasource": "Prometheus",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 63 },
+      "targets": [
+        {
+          "expr": "ClickHouseMetrics_MemoryTracking",
+          "legendFormat": "Memory In Use",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "MergeTree Disk Usage / Available",
+      "id": 23,
+      "datasource": "Prometheus",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 63 },
+      "targets": [
+        {
+          "expr": "ClickHouseAsyncMetrics_TotalBytesOfMergeTreeTables",
+          "legendFormat": "Total Bytes of MergeTree",
+          "refId": "A"
+        },
+        {
+          "expr": "ClickHouseAsyncMetrics_DiskAvailable_default",
+          "legendFormat": "Disk Available (default)",
+          "refId": "B"
+        }
+      ]
+    }
+  ],
+  "schemaVersion": 36,
+  "style": "dark",
+  "tags": ["qos_oracle"],
+  "timezone": "",
+  "title": "QoS Oracle: ClickHouse & Redpanda Overview",
+  "uid": "qos-oracle-clickhouse-redpanda",
+  "version": 2
+}

--- a/oracle/grafana/dashboards/qos_oracle_dashboard.json
+++ b/oracle/grafana/dashboards/qos_oracle_dashboard.json
@@ -1,25 +1,85 @@
 {
   "annotations": {
-    "list": []
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
   },
   "editable": true,
-  "gnetId": null,
+  "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": null,
+  "id": 1,
+  "links": [],
   "panels": [
     {
-      "type": "row",
-      "title": "Redpanda Overview",
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
       "collapsed": false,
-      "panels": []
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 24,
+      "panels": [],
+      "title": "Redpanda Overview",
+      "type": "row"
     },
     {
-      "type": "stat",
-      "title": "Redpanda Uptime (seconds)",
-      "id": 1,
       "datasource": "Prometheus",
-      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 1 },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 1
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "expr": "vectorized_application_uptime",
@@ -27,21 +87,55 @@
           "refId": "A"
         }
       ],
+      "title": "Redpanda Uptime (seconds)",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 1
+      },
+      "id": 2,
       "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
-        "orientation": "auto"
-      }
-    },
-    {
-      "type": "stat",
-      "title": "Redpanda Build Info",
-      "id": 2,
-      "datasource": "Prometheus",
-      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 1 },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "expr": "vectorized_application_build",
@@ -49,21 +143,55 @@
           "refId": "A"
         }
       ],
+      "title": "Redpanda Build Info",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 1
+      },
+      "id": 3,
       "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
-        "orientation": "auto"
-      }
-    },
-    {
-      "type": "stat",
-      "title": "FIPS Mode",
-      "id": 3,
-      "datasource": "Prometheus",
-      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 1 },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "expr": "vectorized_application_fips_mode",
@@ -71,21 +199,55 @@
           "refId": "A"
         }
       ],
+      "title": "FIPS Mode",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 1
+      },
+      "id": 4,
       "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
-        "orientation": "auto"
-      }
-    },
-    {
-      "type": "stat",
-      "title": "Under-Replicated Partitions",
-      "id": 4,
-      "datasource": "Prometheus",
-      "gridPos": { "h": 4, "w": 4, "x": 12, "y": 1 },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "expr": "vectorized_cluster_partition_under_replicated_replicas",
@@ -93,28 +255,100 @@
           "refId": "A"
         }
       ],
-      "options": {
-        "reduceOptions": {
-          "calcs": ["lastNotNull"],
-          "fields": "",
-          "values": false
-        },
-        "orientation": "auto"
-      }
+      "title": "Under-Replicated Partitions",
+      "type": "stat"
     },
     {
-      "type": "row",
-      "title": "Redpanda Traffic & Throughput",
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 },
       "collapsed": false,
-      "panels": []
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 25,
+      "panels": [],
+      "title": "Redpanda Traffic & Throughput",
+      "type": "row"
     },
     {
-      "type": "timeseries",
-      "title": "Records Produced / Fetched per Sec",
-      "id": 5,
       "datasource": "Prometheus",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "expr": "rate(vectorized_cluster_partition_records_produced[5m])",
@@ -126,14 +360,88 @@
           "legendFormat": "Fetched",
           "refId": "B"
         }
-      ]
+      ],
+      "title": "Records Produced / Fetched per Sec",
+      "type": "timeseries"
     },
     {
-      "type": "timeseries",
-      "title": "Bytes Produced / Fetched per Sec",
-      "id": 6,
       "datasource": "Prometheus",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "expr": "rate(vectorized_cluster_partition_bytes_produced_total[5m])",
@@ -145,70 +453,316 @@
           "legendFormat": "Bytes Fetched",
           "refId": "B"
         }
-      ]
+      ],
+      "title": "Bytes Produced / Fetched per Sec",
+      "type": "timeseries"
     },
     {
-      "type": "row",
-      "title": "Redpanda Latencies & Connection Health",
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 14 },
       "collapsed": false,
-      "panels": []
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 14
+      },
+      "id": 26,
+      "panels": [],
+      "title": "Redpanda Latencies & Connection Health",
+      "type": "row"
     },
     {
-      "type": "timeseries",
-      "title": "Kafka Handler Latency (µs)",
-      "id": 7,
       "datasource": "Prometheus",
-      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 15 },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "µs"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 15
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "expr": "rate(vectorized_kafka_handler_latency_microseconds_count[5m])",
           "legendFormat": "Handler Latency",
           "refId": "A"
         }
-      ]
+      ],
+      "title": "Kafka Handler Latency (µs)",
+      "type": "timeseries"
     },
     {
-      "type": "stat",
-      "title": "Active Kafka Connections",
-      "id": 8,
       "datasource": "Prometheus",
-      "gridPos": { "h": 4, "w": 8, "x": 8, "y": 15 },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 8,
+        "y": 15
+      },
+      "id": 8,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "expr": "vectorized_kafka_rpc_active_connections",
           "legendFormat": "{{instance}}",
           "refId": "A"
         }
-      ]
+      ],
+      "title": "Active Kafka Connections",
+      "type": "stat"
     },
     {
-      "type": "stat",
-      "title": "Rejected Kafka Connections",
-      "id": 9,
       "datasource": "Prometheus",
-      "gridPos": { "h": 4, "w": 8, "x": 16, "y": 15 },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 16,
+        "y": 15
+      },
+      "id": 9,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "expr": "vectorized_kafka_rpc_connections_rejected",
           "legendFormat": "Rejected",
           "refId": "A"
         }
-      ]
+      ],
+      "title": "Rejected Kafka Connections",
+      "type": "stat"
     },
     {
-      "type": "row",
-      "title": "Redpanda Resource Usage",
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 23 },
       "collapsed": false,
-      "panels": []
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      },
+      "id": 27,
+      "panels": [],
+      "title": "Redpanda Resource Usage",
+      "type": "row"
     },
     {
-      "type": "timeseries",
-      "title": "CPU Busy ms/s (approx)",
-      "id": 10,
       "datasource": "Prometheus",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 24 },
+      "description": "CPU busy time in ms; using irate for approximate CPU usage.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "expr": "irate(vectorized_reactor_cpu_busy_ms[5m])",
@@ -216,14 +770,88 @@
           "refId": "A"
         }
       ],
-      "description": "CPU busy time in ms; using irate for approximate CPU usage."
+      "title": "CPU Busy ms/s (approx)",
+      "type": "timeseries"
     },
     {
-      "type": "timeseries",
-      "title": "Memory Used / Available",
-      "id": 11,
       "datasource": "Prometheus",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "expr": "vectorized_memory_allocated_memory",
@@ -235,14 +863,89 @@
           "legendFormat": "Available",
           "refId": "B"
         }
-      ]
+      ],
+      "title": "Memory Used / Available",
+      "type": "timeseries"
     },
     {
-      "type": "timeseries",
-      "title": "Disk Usage",
-      "id": 12,
       "datasource": "Prometheus",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 32 },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 32
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "expr": "vectorized_space_management_disk_usage_bytes",
@@ -254,14 +957,88 @@
           "legendFormat": "Target Disk Size",
           "refId": "B"
         }
-      ]
+      ],
+      "title": "Disk Usage",
+      "type": "timeseries"
     },
     {
-      "type": "timeseries",
-      "title": "I/O Queue Delays & Consumption",
-      "id": 13,
       "datasource": "Prometheus",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 32 },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 32
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "expr": "irate(vectorized_io_queue_delay[5m])",
@@ -273,161 +1050,825 @@
           "legendFormat": "I/O Consumption (ms)",
           "refId": "B"
         }
-      ]
+      ],
+      "title": "I/O Queue Delays & Consumption",
+      "type": "timeseries"
     },
     {
-      "type": "row",
-      "title": "ClickHouse Overview",
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 40 },
       "collapsed": false,
-      "panels": []
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 40
+      },
+      "id": 28,
+      "panels": [],
+      "title": "ClickHouse Overview",
+      "type": "row"
     },
     {
-      "type": "stat",
-      "title": "Total Queries",
-      "id": 14,
       "datasource": "Prometheus",
-      "gridPos": { "h": 4, "w": 8, "x": 0, "y": 41 },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 0,
+        "y": 41
+      },
+      "id": 14,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "expr": "ClickHouseProfileEvents_Query",
           "legendFormat": "All Queries",
           "refId": "A"
         }
-      ]
+      ],
+      "title": "Total Queries",
+      "type": "stat"
     },
     {
-      "type": "stat",
-      "title": "Select Queries (Total)",
-      "id": 15,
       "datasource": "Prometheus",
-      "gridPos": { "h": 4, "w": 8, "x": 8, "y": 41 },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 8,
+        "y": 41
+      },
+      "id": 15,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "expr": "ClickHouseProfileEvents_SelectQuery",
           "legendFormat": "Select",
           "refId": "A"
         }
-      ]
+      ],
+      "title": "Select Queries (Total)",
+      "type": "stat"
     },
     {
-      "type": "stat",
-      "title": "Insert Queries (Total)",
-      "id": 16,
       "datasource": "Prometheus",
-      "gridPos": { "h": 4, "w": 8, "x": 16, "y": 41 },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 16,
+        "y": 41
+      },
+      "id": 16,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "expr": "ClickHouseProfileEvents_InsertQuery",
           "legendFormat": "Insert",
           "refId": "A"
         }
-      ]
+      ],
+      "title": "Insert Queries (Total)",
+      "type": "stat"
     },
     {
-      "type": "timeseries",
-      "title": "Queries per Second",
-      "id": 17,
       "datasource": "Prometheus",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 45 },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 45
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "expr": "rate(ClickHouseProfileEvents_Query[5m])",
           "legendFormat": "Queries/s",
           "refId": "A"
         }
-      ]
+      ],
+      "title": "Queries per Second",
+      "type": "timeseries"
     },
     {
-      "type": "timeseries",
-      "title": "Query Time (µs) Rate",
-      "id": 18,
       "datasource": "Prometheus",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 45 },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "µs"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 45
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "expr": "rate(ClickHouseProfileEvents_QueryTimeMicroseconds[5m])",
           "legendFormat": "Query Time µs/s",
           "refId": "A"
         }
-      ]
+      ],
+      "title": "Query Time (µs) Rate",
+      "type": "timeseries"
     },
     {
-      "type": "row",
-      "title": "ClickHouse Inserts & Merges",
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 53 },
       "collapsed": false,
-      "panels": []
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 53
+      },
+      "id": 29,
+      "panels": [],
+      "title": "ClickHouse Inserts & Merges",
+      "type": "row"
     },
     {
-      "type": "timeseries",
-      "title": "Inserted Rows/s",
-      "id": 19,
       "datasource": "Prometheus",
-      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 54 },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 54
+      },
+      "id": 19,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "expr": "rate(ClickHouseProfileEvents_InsertedRows[5m])",
           "legendFormat": "Rows/s",
           "refId": "A"
         }
-      ]
+      ],
+      "title": "Inserted Rows/s",
+      "type": "timeseries"
     },
     {
-      "type": "timeseries",
-      "title": "Merged Rows/s",
-      "id": 20,
       "datasource": "Prometheus",
-      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 54 },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 54
+      },
+      "id": 20,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "expr": "rate(ClickHouseProfileEvents_MergedRows[5m])",
           "legendFormat": "Merged/s",
           "refId": "A"
         }
-      ]
+      ],
+      "title": "Merged Rows/s",
+      "type": "timeseries"
     },
     {
-      "type": "timeseries",
-      "title": "Merges Time (ms/s)",
-      "id": 21,
       "datasource": "Prometheus",
-      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 54 },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 54
+      },
+      "id": 21,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "expr": "rate(ClickHouseProfileEvents_MergesTimeMilliseconds[5m])",
           "legendFormat": "Merges Time ms/s",
           "refId": "A"
         }
-      ]
+      ],
+      "title": "Merges Time (ms/s)",
+      "type": "timeseries"
     },
     {
-      "type": "row",
-      "title": "ClickHouse Resource Usage",
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 62 },
       "collapsed": false,
-      "panels": []
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 62
+      },
+      "id": 30,
+      "panels": [],
+      "title": "ClickHouse Resource Usage",
+      "type": "row"
     },
     {
-      "type": "timeseries",
-      "title": "ClickHouse Memory Tracking (bytes)",
-      "id": 22,
       "datasource": "Prometheus",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 63 },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 63
+      },
+      "id": 22,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "expr": "ClickHouseMetrics_MemoryTracking",
           "legendFormat": "Memory In Use",
           "refId": "A"
         }
-      ]
+      ],
+      "title": "ClickHouse Memory Tracking (bytes)",
+      "type": "timeseries"
     },
     {
-      "type": "timeseries",
-      "title": "MergeTree Disk Usage / Available",
-      "id": 23,
       "datasource": "Prometheus",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 63 },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 63
+      },
+      "id": 23,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "expr": "ClickHouseAsyncMetrics_TotalBytesOfMergeTreeTables",
@@ -439,14 +1880,22 @@
           "legendFormat": "Disk Available (default)",
           "refId": "B"
         }
-      ]
+      ],
+      "title": "MergeTree Disk Usage / Available",
+      "type": "timeseries"
     }
   ],
-  "schemaVersion": 36,
-  "style": "dark",
-  "tags": ["qos_oracle"],
+  "preload": false,
+  "schemaVersion": 41,
+  "tags": [
+    "qos_oracle"
+  ],
+  "templating": {
+    "list": []
+  },
+  "timepicker": {},
   "timezone": "",
   "title": "QoS Oracle: ClickHouse & Redpanda Overview",
   "uid": "qos-oracle-clickhouse-redpanda",
-  "version": 2
+  "version": 8
 }

--- a/oracle/grafana/provisioning/dashboards/dashboard.yaml
+++ b/oracle/grafana/provisioning/dashboards/dashboard.yaml
@@ -1,0 +1,10 @@
+apiVersion: 1
+providers:
+  - name: 'Local Dashboards'
+    orgId: 1
+    folder: ''
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    options:
+      path: /var/lib/grafana/dashboards

--- a/oracle/grafana/provisioning/datasources/datasource.yaml
+++ b/oracle/grafana/provisioning/datasources/datasource.yaml
@@ -1,0 +1,7 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true

--- a/oracle/prometheus/prometheus.yml
+++ b/oracle/prometheus/prometheus.yml
@@ -1,0 +1,11 @@
+global:
+  scrape_interval: 60s
+
+scrape_configs:
+  - job_name: 'redpanda'
+    static_configs:
+      - targets: ['redpanda:9644']
+
+  - job_name: 'clickhouse'
+    static_configs:
+      - targets: ['clickhouse-server:9363']


### PR DESCRIPTION
- adds grafana and prometheus to the stack, configured to scrape clickhouse and redpanda (working on my setup)
- remove an unused config in settings.xml, and use it (that pre-existing confing was getting rejected by clickhouse)
- add a dashboard for key clickhouse / redpanda metrics